### PR TITLE
add missing asterisk for asciidoc bold in section 4.10.7

### DIFF
--- a/doc/ra_ospnet_ch4_overcloud.adoc
+++ b/doc/ra_ospnet_ch4_overcloud.adoc
@@ -1042,7 +1042,7 @@ Here is an example of the changes required for the controller role (in bold):
                       *- '/'*
                       *- - {get_param: ControlPlaneIp}*
                         *- {get_param: ControlPlaneSubnetCidr}*
-              routes:*
+              *routes:*
                 -
                   *ip_netmask: 169.254.169.254/32*
                   *next_hop: {get_param: EC2MetadataIp}*


### PR DESCRIPTION
missing asterisk means this asterisk shows up in example code causing problems
